### PR TITLE
Update BoardConfig.mk

### DIFF
--- a/redroid_x86_64/BoardConfig.mk
+++ b/redroid_x86_64/BoardConfig.mk
@@ -7,3 +7,5 @@ BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := ext4
 
 DEVICE_MANIFEST_FILE += device/redroid/manifest.xml
 
+# Increase the system image partition size to 2 GB
+BOARD_SYSTEMIMAGE_PARTITION_SIZE := 2147483648


### PR DESCRIPTION
Fix error when building Redroid 8.1 with OpenGApps

```
e2fsdroid -e -p out/target/product/redroid_x86_64/system -S out/target/product/redroid_x86_64/obj/ETC/file_contexts.bin_intermediates/file_contexts.bin -f /tmp/tmpk2k1MA -a / out/target/product/redroid_x86_64/obj/PACKAGING/systemimage_intermediates/system.img

__populate_fs: Could not allocate block in ext2 filesystem while writing file "boot-framework.oat"

e2fsdroid: Could not allocate block in ext2 filesystem while populating file system Out of space? the tree size of out/target/product/redroid_x86_64/system is (MB):
1667    out/target/product/redroid_x86_64/system
The max is 1536 MB.

ninja: build stopped: subcommand failed.
18:23:16 ninja failed with: exit status 1

#### failed to build some targets (50:08 (mm:ss)) ####
```